### PR TITLE
Adds cache timeout for playlist && Adds hook callback for playlist updates

### DIFF
--- a/sxm.py
+++ b/sxm.py
@@ -12,7 +12,7 @@ class SiriusXM:
     REST_FORMAT = 'https://player.siriusxm.com/rest/v2/experience/modules/{}'
     LIVE_PRIMARY_HLS = 'https://siriusxm-priprodlive.akamaized.net'
 
-    def __init__(self, username, password):
+    def __init__(self, username, password, update_handler=None):
         self.session = requests.Session()
         self.session.headers.update({'User-Agent': self.USER_AGENT})
         self.username = username
@@ -23,6 +23,9 @@ class SiriusXM:
         # vars to manage session cache
         self.last_renew = None
         self.update_interval = 30
+
+        # hook function to call whenever the playlist updates
+        self.update_handler = update_handler
 
     @staticmethod
     def log(x):
@@ -213,6 +216,9 @@ class SiriusXM:
                 playlist_url = playlist_info['url'].replace('%Live_Primary_HLS%', self.LIVE_PRIMARY_HLS)
                 self.playlists[channel_id] = self.get_playlist_variant_url(playlist_url)
                 self.last_renew = time.time()
+
+                if self.update_handler is not None:
+                    self.update_handler(data)
                 return self.playlists[channel_id]
 
         return None

--- a/sxm.py
+++ b/sxm.py
@@ -181,7 +181,7 @@ class SiriusXM:
         try:
             self.update_interval = int(
                 data['ModuleListResponse']['moduleList']['modules'][0]['updateFrequency']
-            ) - 5
+            )
             message = data['ModuleListResponse']['messages'][0]['message']
             message_code = data['ModuleListResponse']['messages'][0]['code']
         except (KeyError, IndexError):


### PR DESCRIPTION
* **Uses `update_frequency` from the playlist data that returns as part of `get_playlist_data` to automatically invalidate the playlist data.** This greatly reduces the 403 session expired request and leads to smoother playback.

* **Adds a hook in `get_playlist_data` to call an arbitrary callback function whenever the playlist updates.** This can be used by external programs to update status of what is currently playing really easily. 