### PR TITLE
Update to use SXMAUTHNEW cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is forked from andrew0 with minimal changes:
 
 * Updated SXM auth cookie name (so that the system actually authenticates now...)
-* Updated AWS cookie name (again, si that it actually authenticates again...)
+* Updated AWS cookie name (again, so that it actually authenticates again...)
 * Added -e (--env) parameter to use SXM_USER and SXM_PASS environment variables to override username and password on command line
   * Note: The username and password parameters are still required:  just put something like "user" and "pass".
 * I added a geric systemd unit file and an override file customized for my use case.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is forked from andrew0 with minimal changes:
 * Updated AWS cookie name (again, so that it actually authenticates again...)
 * Added -e (--env) parameter to use SXM_USER and SXM_PASS environment variables to override username and password on command line
   * Note: The username and password parameters are still required:  just put something like "user" and "pass".
-* I added a geric systemd unit file and an override file customized for my use case.
+* I added a generic systemd unit file and an override file customized for my use case.
     
 Original Readme:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This is forked from andrew0 with minimal changes:
 
-* Updated cookie name (so that the system actually authenticates now...)
+* Updated SXM auth cookie name (so that the system actually authenticates now...)
+* Updated AWS cookie name (again, si that it actually authenticates again...)
 * Added -e (--env) parameter to use SXM_USER and SXM_PASS environment variables to override username and password on command line
   * Note: The username and password parameters are still required:  just put something like "user" and "pass".
 * I added a geric systemd unit file and an override file customized for my use case.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is forked from andrew0 with minimal changes:
 * Updated cookie name (so that the system actually authenticates now...)
 * Added -e (--env) parameter to use SXM_USER and SXM_PASS environment variables to override username and password on command line
   * Note: The username and password parameters are still required:  just put something like "user" and "pass".
+* I added a geric systemd unit file and an override file customized for my use case.
     
 Original Readme:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # SiriusXM
 
+This is forked from andrew0 with minimal changes:
+
+* Updated cookie name (so that the system actually authenticates now...)
+* Added -e (--env) parameter to use SXM_USER and SXM_PASS environment variables to override username and password on command line
+  * Note: The username and password parameters are still required:  just put something like "user" and "pass".
+    
+Original Readme:
+
 This script creates a server that serves HLS streams for SiriusXM channels. To use it, pass your SiriusXM username and password and a port to run the server on. For example, you start the server by running:
 `python3 sxm.py myuser mypassword -p 8888`
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is forked from andrew0 with minimal changes:
 
 * Updated SXM auth cookie name (so that the system actually authenticates now...)
+  * 20240131 And changed it again...
 * Updated AWS cookie name (again, so that it actually authenticates again...)
 * Added -e (--env) parameter to use SXM_USER and SXM_PASS environment variables to override username and password on command line
   * Note: The username and password parameters are still required:  just put something like "user" and "pass".

--- a/override.conf
+++ b/override.conf
@@ -1,0 +1,7 @@
+[Service]
+WorkingDirectory=/data/mpd/tools/sxm
+EnvironmentFile=/data/mpd/tools/sxm/id
+User=mpd
+ExecStart=
+# NOTE:  With EnvironmentFile and the -e parameter, user and pw are ignored.
+ExecStart=/usr/bin/python3 /data/mpd/tools/sxm/sxm.py user pw -e -p 8888

--- a/sxm.py
+++ b/sxm.py
@@ -29,7 +29,7 @@ class SiriusXM:
         return 'SXMAUTHNEW' in self.session.cookies
 
     def is_session_authenticated(self):
-        return 'AWSELB' in self.session.cookies and 'JSESSIONID' in self.session.cookies
+        return 'AWSALB' in self.session.cookies and 'JSESSIONID' in self.session.cookies
 
     def get(self, method, params, authenticate=True):
         if authenticate and not self.is_session_authenticated() and not self.authenticate():

--- a/sxm.py
+++ b/sxm.py
@@ -25,7 +25,7 @@ class SiriusXM:
         print('{} <SiriusXM>: {}'.format(datetime.datetime.now().strftime('%d.%b %Y %H:%M:%S'), x))
 
     def is_logged_in(self):
-        return 'SXMAUTH' in self.session.cookies
+        return 'SXMAUTHNEW' in self.session.cookies
 
     def is_session_authenticated(self):
         return 'AWSELB' in self.session.cookies and 'JSESSIONID' in self.session.cookies

--- a/sxm.py
+++ b/sxm.py
@@ -26,7 +26,7 @@ class SiriusXM:
         print('{} <SiriusXM>: {}'.format(datetime.datetime.now().strftime('%d.%b %Y %H:%M:%S'), x))
 
     def is_logged_in(self):
-        return 'SXMAUTHNEW' in self.session.cookies
+        return 'SXMDATA' in self.session.cookies
 
     def is_session_authenticated(self):
         return 'AWSALB' in self.session.cookies and 'JSESSIONID' in self.session.cookies

--- a/sxm.py
+++ b/sxm.py
@@ -5,6 +5,7 @@ import urllib.parse
 import json
 import time, datetime
 import sys
+import os
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class SiriusXM:
@@ -355,8 +356,14 @@ if __name__ == '__main__':
     parser.add_argument('password')
     parser.add_argument('-l', '--list', required=False, action='store_true', default=False)
     parser.add_argument('-p', '--port', required=False, default=9999, type=int)
+    parser.add_argument('-e', '--env',  required=False, action='store_true', default=False)
     args = vars(parser.parse_args())
-    
+    if args['env']:
+        if "SXM_USER" in os.environ:
+            args['username'] = os.environ.get('SXM_USER')
+        if "SXM_PASS" in os.environ:
+            args['password'] = os.environ.get('SXM_PASS')
+
     sxm = SiriusXM(args['username'], args['password'])
     if args['list']:
         channels = list(sorted(sxm.get_channels(), key=lambda x: (not x.get('isFavorite', False), int(x.get('siriusChannelNumber', 9999)))))

--- a/sxm.service
+++ b/sxm.service
@@ -1,0 +1,25 @@
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# sxm.py  Orginal code:   https://github.com/andrew0/SiriusXM
+# Updated fork at:  https://github.com/fts-tmassey/SiriusXM
+#
+[Unit]
+Description=SiriusXM Channel Service
+Requires=network.target
+
+[Service]
+WorkingDirectory=/usr/local/sxm
+Type=exec
+ExecStart=/usr/bin/python3 /usr/local/sxm/sxm.py user password -p 8888
+Restart=always
+# disallow writing to /usr, /bin, /sbin, ...
+ProtectSystem=yes
+# more paranoid security settings
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/sxm.service
+++ b/sxm.service
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # sxm.py  Orginal code:   https://github.com/andrew0/SiriusXM
-# Updated fork at:  https://github.com/fts-tmassey/SiriusXM
+# Updated fork at:  https://github.com/mim-tmassey/SiriusXM
 #
 [Unit]
 Description=SiriusXM Channel Service


### PR DESCRIPTION
Getting "Unable to authenticate because login failed" when trying to connect.  Could login successfully using https://player.siriusxm.com so credentials were correct.  Examining the cookies within the browser seem to indicate that SXM changed "SXMAUTH" to "SXMAUTHNEW".  Updated code and was able to list/play channels.